### PR TITLE
feat: Rails6における複合データベースの設定を追加する

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,8 @@ Ruby on Railsを遊び尽くすリポジトリ
    ```
 1. サブシステム用のDDLとDMLを流し込む
    ```sh
-   docker-compose exec db psql -U postgres -d sub_database -f /tmp/docker_files/sub_database.sql
+   docker-compose exec db psql -U postgres -d sub_database_development -f /tmp/docker_files/sub_database.sql
+   docker-compose exec db psql -U postgres -d sub_database_test -f /tmp/docker_files/sub_database.sql
    ```
 1. Railsを起動する
 - TODO

--- a/config/database.yml
+++ b/config/database.yml
@@ -13,6 +13,7 @@ development:
   sub_system:
     <<: *default
     database: sub_database_development
+    migrations_paths: db/migrate/sub_system
 
 test:
   primary:
@@ -21,6 +22,7 @@ test:
   sub_system:
     <<: *default
     database: sub_database_test
+    migrations_paths: db/migrate/sub_system
 
 production:
   primary:
@@ -29,3 +31,4 @@ production:
   sub_system:
     <<: *default
     database: sub_database_production
+    migrations_paths: db/migrate/sub_system

--- a/config/database.yml
+++ b/config/database.yml
@@ -7,7 +7,7 @@ default: &default
   password: <%= ENV['POSTGRES_PASSWORD'] %>
 
 development:
-  main_system:
+  primary:
     <<: *default
     database: pwr_development
   sub_system:
@@ -15,7 +15,7 @@ development:
     database: sub_database_development
 
 test:
-  main_system:
+  primary:
     <<: *default
     database: pwr_test
   sub_system:
@@ -23,7 +23,7 @@ test:
     database: sub_database_test
 
 production:
-  main_system:
+  primary:
     <<: *default
     database: pwr_production
   sub_system:

--- a/db/migrate/20230919125310_add_kokushi_to_daimyos.rb
+++ b/db/migrate/20230919125310_add_kokushi_to_daimyos.rb
@@ -1,0 +1,9 @@
+class AddKokushiToDaimyos < ActiveRecord::Migration[6.0]
+  def up
+    add_column :daimyos, :kokushi, :string, limit: 16, null: true, comment: '国司'
+  end
+
+  def down
+    remove_column :daimyos, :kokushi
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2023_02_23_064423) do
+ActiveRecord::Schema.define(version: 2023_09_19_125310) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -21,6 +21,7 @@ ActiveRecord::Schema.define(version: 2023_02_23_064423) do
     t.date "died_on", comment: "没年月日"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.string "kokushi", limit: 16, comment: "国司"
   end
 
 end

--- a/db/sub_system_schema.rb
+++ b/db/sub_system_schema.rb
@@ -1,0 +1,29 @@
+# This file is auto-generated from the current state of the database. Instead
+# of editing this file, please use the migrations feature of Active Record to
+# incrementally modify your database, and then regenerate this schema definition.
+#
+# This file is the source Rails uses to define your schema when running `rails
+# db:schema:load`. When creating a new database, `rails db:schema:load` tends to
+# be faster and is potentially less error prone than running all of your
+# migrations from scratch. Old migrations may fail to apply correctly if those
+# migrations use external dependencies or application code.
+#
+# It's strongly recommended that you check this file into your version control system.
+
+ActiveRecord::Schema.define(version: 0) do
+
+  # These are extensions that must be enabled in order to support this database
+  enable_extension "plpgsql"
+
+  create_table "castles", id: :serial, force: :cascade do |t|
+    t.string "name", limit: 32, null: false
+    t.integer "prefecture", null: false
+  end
+
+  create_table "prefectures", id: :serial, force: :cascade do |t|
+    t.string "name", limit: 32, null: false
+    t.string "name_en", limit: 32, null: false
+  end
+
+  add_foreign_key "castles", "prefectures", column: "prefecture", name: "castles_prefecture_fkey"
+end

--- a/docker_files/docker/Makefile
+++ b/docker_files/docker/Makefile
@@ -25,7 +25,7 @@ create:
 	docker-compose exec app bundle exec rails db:create
 
 migrate:
-	docker-compose exec app bundle exec rails db:migrate:main_system
+	docker-compose exec app bundle exec rails db:migrate:primary
 
 rollback:
 	docker-compose exec app bundle exec rails db:rollback

--- a/docker_files/docker/Makefile
+++ b/docker_files/docker/Makefile
@@ -25,7 +25,7 @@ create:
 	docker-compose exec app bundle exec rails db:create
 
 migrate:
-	docker-compose exec app bundle exec rails db:migrate:primary
+	docker-compose exec app bundle exec rails db:migrate
 
 rollback:
 	docker-compose exec app bundle exec rails db:rollback

--- a/docker_files/local/Makefile
+++ b/docker_files/local/Makefile
@@ -25,7 +25,7 @@ create:
 	docker-compose exec app bundle exec rails db:create
 
 migrate:
-	bundle exec rails db:migrate:primary
+	bundle exec rails db:migrate
 
 rollback:
 	bundle exec rails db:rollback

--- a/docker_files/local/Makefile
+++ b/docker_files/local/Makefile
@@ -25,7 +25,7 @@ create:
 	docker-compose exec app bundle exec rails db:create
 
 migrate:
-	bundle exec rails db:migrate:main_system
+	bundle exec rails db:migrate:primary
 
 rollback:
 	bundle exec rails db:rollback


### PR DESCRIPTION
## 概要
- 以下の対応だけでは色々と問題が起きた
  - #5

## 発生した問題
### `db:migrate:main_system`を実行してもと、`schema.rb`が更新されない
- `schema.rb`を使用したい場合は、名前空間を`primary`にする必要がる

### `db:migrate`を実行すると、サブシステム用のDBにまでマイグレーションファイルが反映されてしまう
- `migrations_paths`を指定することで、デフォルト(`db/migrate`)配下のファイルを実行しないようになる

### `db:migrate:primary`を実行しても、`schema.rb`が更新されない
- **未解決**

### サブシステム用のデータベースをマイグレーション等の管理外にしたい
- **未解決**