### PR TITLE
feat: compose.yamlのバージョンを削除する

### DIFF
--- a/docker_files/docker/compose.yml
+++ b/docker_files/docker/compose.yml
@@ -1,5 +1,3 @@
-version: '3'
-
 services:
   app:
     build:


### PR DESCRIPTION
WARN[0000] play_with_rails/compose.yml: `version` is obsolete